### PR TITLE
add example Nuget.config file

### DIFF
--- a/TwoDay/2.2/Code/Completed/NuGet.Config
+++ b/TwoDay/2.2/Code/Completed/NuGet.Config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+		  <!--<add key="Example Nuget Repo" value="http://addressToTheServer/nuget" />-->
+  </packageSources>
+  <disabledPackageSources />
+</configuration>


### PR DESCRIPTION
Here is the example Nuget.config file. It could be used to add private NuGet servers to individual folders. This prevents issues trying to get to private servers when working on public projects.